### PR TITLE
fixing tag_id for tag_id_seq

### DIFF
--- a/ereuse_tag/migrations/versions/386b38db550e_change_tag_id_for_tag_id_seq.py
+++ b/ereuse_tag/migrations/versions/386b38db550e_change_tag_id_for_tag_id_seq.py
@@ -1,0 +1,24 @@
+"""change tag_id for tag_id_seq
+
+Revision ID: 386b38db550e
+Revises: 538f08b97774
+Create Date: 2020-10-06 18:20:21.419649
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '386b38db550e'
+down_revision = '538f08b97774'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/ereuse_tag/model.py
+++ b/ereuse_tag/model.py
@@ -13,7 +13,7 @@ from ereuse_tag.db import db
 class Tag(db.Model):
     _id = Column('id',
                  db.BigInteger,
-                 Sequence('tag_id'),
+                 Sequence('tag_id_seq'),
                  check_range('id', 1, 10 ** 12),  # Imposed by QR size
                  primary_key=True)
     secondary = Column(db.Unicode)
@@ -117,7 +117,7 @@ class Link(db.Model):
     Stores URLs and provides a hashed ID back.
     """
     # todo develop
-    id = Column(db.BigInteger, Sequence('link_id'), primary_key=True)
+    id = Column(db.BigInteger, Sequence('link_id_seq'), primary_key=True)
     url = Column(URLType, nullable=False, unique=True)
     updated = db.Column(db.TIMESTAMP(timezone=True),
                         server_default=db.text('CURRENT_TIMESTAMP'),


### PR DESCRIPTION
fixing bug
The model of Link have a id sequence as link_id insted of link_id_seq. But in database is used link_id_seq as create normaly alembic
Is necessary to change Link and Tag models